### PR TITLE
Replace malloc.h with stdlib.h

### DIFF
--- a/src/host/libpixyusb2/include/libpixyusb2.h
+++ b/src/host/libpixyusb2/include/libpixyusb2.h
@@ -22,7 +22,7 @@
 #define RBUF_LEN      0x200
 
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include "usblink.h"
 #include "util.h"


### PR DESCRIPTION
Has not been tested on Windows yet - if someone else could confirm that would be great.

This fixes the missing include on macos that doesn't have `malloc.h`.